### PR TITLE
Initial scaffolding for a Physarum transport model

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,53 @@
+{
+  "fileScopedDeclarationPrivacy" : {
+    "accessLevel" : "private"
+  },
+  "indentation" : {
+    "spaces" : 2
+  },
+  "indentConditionalCompilationBlocks" : true,
+  "lineBreakAroundMultilineExpressionChainComponents" : false,
+  "lineBreakBeforeControlFlowKeywords" : false,
+  "lineBreakBeforeEachArgument" : false,
+  "lineBreakBeforeEachGenericRequirement" : false,
+  "lineLength" : 100,
+  "maximumBlankLines" : 1,
+  "prioritizeKeepingFunctionOutputTogether" : false,
+  "respectsExistingLineBreaks" : true,
+  "rules" : {
+    "AllPublicDeclarationsHaveDocumentation" : true,
+    "AlwaysUseLowerCamelCase" : true,
+    "AmbiguousTrailingClosureOverload" : true,
+    "BeginDocumentationCommentWithOneLineSummary" : true,
+    "DoNotUseSemicolons" : true,
+    "DontRepeatTypeInStaticProperties" : true,
+    "FileprivateAtFileScope" : true,
+    "FullyIndirectEnum" : true,
+    "GroupNumericLiterals" : true,
+    "IdentifiersMustBeASCII" : false,
+    "NeverForceUnwrap" : true,
+    "NeverUseForceTry" : true,
+    "NeverUseImplicitlyUnwrappedOptionals" : true,
+    "NoAccessLevelOnExtensionDeclaration" : true,
+    "NoBlockComments" : true,
+    "NoCasesWithOnlyFallthrough" : true,
+    "NoEmptyTrailingClosureParentheses" : true,
+    "NoLabelsInCasePatterns" : true,
+    "NoLeadingUnderscores" : true,
+    "NoParensAroundConditions" : true,
+    "NoVoidReturnOnFunctionSignature" : true,
+    "OneCasePerLine" : true,
+    "OneVariableDeclarationPerLine" : true,
+    "OnlyOneTrailingClosureArgument" : true,
+    "OrderedImports" : true,
+    "ReturnVoidInsteadOfEmptyTuple" : true,
+    "UseLetInEveryBoundCaseVariable" : true,
+    "UseShorthandTypeNames" : true,
+    "UseSingleLinePropertyGetter" : true,
+    "UseSynthesizedInitializer" : true,
+    "UseTripleSlashForDocumentationComments" : true,
+    "ValidateDocumentationComments" : true
+  },
+  "tabWidth" : 8,
+  "version" : 1
+}

--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Fractals)
+add_subdirectory(Physarum)

--- a/Examples/Physarum/CMakeLists.txt
+++ b/Examples/Physarum/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(Physarum
+  main.swift)
+target_link_libraries(Physarum PRIVATE
+  ModelSupport
+  SwiftRT)
+
+
+install(TARGETS Physarum
+  DESTINATION bin)

--- a/Examples/Physarum/README.md
+++ b/Examples/Physarum/README.md
@@ -1,0 +1,20 @@
+# Physarum transport model
+
+This implements a version of the [Physarum transport model](https://www.sagejenson.com/physarum)
+described by Sage Jenson, inspired by [“Characteristics of pattern formation and evolution in 
+approximations of Physarum transport networks.”](http://eprints.uwe.ac.uk/15260/1/artl.2010.16.2.pdf)
+
+Representative animated images of the evolution of the world state will be written into `output/`.
+
+## Setup
+
+To begin, you'll need the [latest version of Swift for
+TensorFlow](https://github.com/tensorflow/swift/blob/master/Installation.md)
+installed. Make sure you've added the correct version of `swift` to your path.
+
+To run the model, use the following:
+
+```sh
+cd swift-models
+swift run -c release Physarum
+```

--- a/Examples/Physarum/main.swift
+++ b/Examples/Physarum/main.swift
@@ -1,0 +1,111 @@
+// Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import ModelSupport
+import SwiftRT
+
+let stepCount = 5
+let gridSize = 512
+let particleCount = 1024
+let senseAngle = 0.20 * Float.pi
+let senseDistance: Float = 4.0
+let evaporationRate: Float = 0.95
+let moveAngle = 0.1 * Float.pi
+let moveStep: Float = 2.0
+let channelSize = 1
+let captureImage = true
+
+let runOnCPU = false
+
+if runOnCPU { use(device: 0) }
+
+var grid = [repeating(0, (gridSize, gridSize), type: Float.self),
+            repeating(0, (gridSize, gridSize), type: Float.self)]
+var positions = TensorR2<Float>(randomUniform: Shape2(particleCount, 2)) * Float(gridSize)
+var headings = TensorR1<Float>(randomUniform: particleCount) * 2.0 * Float.pi
+
+let gridShape = Shape2(gridSize, gridSize)
+
+// TODO: Implement mask
+//extension Tensor where Scalar: Numeric {
+//  func mask(condition: (Tensor) -> Tensor<Bool>) -> Tensor {
+//    let satisfied = condition(self)
+//    return Tensor(zerosLike: self)
+//      .replacing(with: Tensor(onesLike: self), where: satisfied)
+//  }
+//}
+
+// TODO: Implement angleToVector
+//func angleToVector(_ angle: Tensor<Float>) -> Tensor<Float> {
+//  return Tensor(stacking: [cos(angle), sin(angle)], alongAxis: -1)
+//}
+
+func step(phase: Int) {
+  // TODO: Implement all this.
+  /*
+  var currentGrid = grid[phase]
+  // Perceive
+  let senseDirection = headings.expandingShape(at: 1).broadcasted(to: [particleCount, 3])
+    + Tensor<Float>([-moveAngle, 0.0, moveAngle], on: device)
+  let sensingOffset = angleToVector(senseDirection) * senseDistance
+  let sensingPosition = positions.expandingShape(at: 1) + sensingOffset
+  // TODO: This wrapping around negative values needs to be fixed.
+  let sensingIndices = abs(Tensor<Int32>(sensingPosition))
+    % (gridShape.expandingShape(at: 0).expandingShape(at: 0))
+  let sensedValues = currentGrid.expandingShape(at: 2)
+    .dimensionGathering(atIndices: sensingIndices).squeezingShape(at: 2)
+  
+  // Move
+  let lowValues = sensedValues.argmin(squeezingAxis: -1)
+  let highValues = sensedValues.argmax(squeezingAxis: -1)
+  let middleMask = lowValues.mask { $0 .== 1 }
+  let middleDistribution = Tensor<Float>(randomUniform: [particleCount], on: device)
+  let randomTurn = middleDistribution.mask { $0 .< 0.1 } * Tensor<Float>(middleMask)
+  let turn = Tensor<Float>(highValues - 1) * Tensor<Float>(1 - middleMask) + randomTurn
+  headings += (turn * moveAngle)
+  positions += angleToVector(headings) * moveStep
+  
+  // Deposit
+  // TODO: This wrapping around negative values needs to be fixed.
+  // TODO: XLA errors out with "Invalid argument: Automatic shape inference not supported: s32[1024,2] and s32[1,1,2]"
+  // if the manual shape expansion isn't present here.
+  let depositIndices = abs(Tensor<Int32>(positions)) % (gridShape.expandingShape(at: 0))
+  let deposits = scatterValues.dimensionScattering(atIndices: depositIndices, shape: gridShape)
+  currentGrid += deposits
+  
+  // Diffuse
+  currentGrid = currentGrid.expandingShape(at: 0).expandingShape(at: 3)
+  currentGrid = currentGrid.padded(forSizes: [(0, 0), (1, 1), (1, 1), (0, 0)], mode: .reflect)
+  currentGrid = avgPool2D(currentGrid, filterSize: (1, 3, 3, 1), strides: (1, 1, 1, 1), padding: .valid)
+  currentGrid = currentGrid * evaporationRate
+  grid[1 - phase] = currentGrid.squeezingShape(at: 3).squeezingShape(at: 0)
+  */
+}
+
+let start = Date()
+
+var steps: [TensorR3<Float>] = []
+for stepIndex in 0..<stepCount {
+  step(phase: stepIndex % 2)
+  if captureImage {
+    steps.append(expand(dims: grid[0], axis: 2) * 255.0)
+  }
+}
+
+print("Total calculation time: \(String(format: "%.4f", Date().timeIntervalSince(start))) seconds")
+
+if captureImage {
+  try steps.saveAnimatedImage(directory: "output", name: "physarum", delay: 1)
+}

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,10 @@ let package = Package(
        .target(
            name: "Fractals",
            dependencies: ["ArgumentParser", "ModelSupport", "SwiftRT"],
-           path: "Examples/Fractals")
+           path: "Examples/Fractals"),
+      .target(
+          name: "Physarum",
+          dependencies: ["ModelSupport", "SwiftRT"],
+          path: "Examples/Physarum")
     ]
 )

--- a/Support/CMakeLists.txt
+++ b/Support/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_subdirectory(STBImage)
 
 add_library(ModelSupport
+  AnimatedImage.swift
   FileManagement.swift
   FileSystem.swift
   FoundationFileSystem.swift
+  GIF.swift
   Image.swift
   Stderr.swift)
 set_target_properties(ModelSupport PROPERTIES


### PR DESCRIPTION
This sets up an initial Physarum transport model, which is currently nonfunctional. The scaffolding builds and sets up some initial tensors under CMake and SwiftPM.

This also introduces an initial .swift-format for the repository.