### PR TITLE
Fixing the build for CMake with CUDA

### DIFF
--- a/Examples/Fractals/CMakeLists.txt
+++ b/Examples/Fractals/CMakeLists.txt
@@ -9,6 +9,11 @@ target_link_libraries(Fractals PRIVATE
   ModelSupport
   SwiftRT)
 
+if(SWIFTRT_ENABLE_CUDA)
+find_package(CUDAToolkit REQUIRED)
+target_link_libraries(Fractals PRIVATE
+  CUDA::cudart)
+endif()
 
 install(TARGETS Fractals
   DESTINATION bin)

--- a/Examples/Physarum/CMakeLists.txt
+++ b/Examples/Physarum/CMakeLists.txt
@@ -5,6 +5,11 @@ target_link_libraries(Physarum PRIVATE
   ModelSupport
   SwiftRT)
 
+if(SWIFTRT_ENABLE_CUDA)
+find_package(CUDAToolkit REQUIRED)
+target_link_libraries(Physarum PRIVATE
+  CUDA::cudart)
+endif()
 
 install(TARGETS Physarum
   DESTINATION bin)


### PR DESCRIPTION
Incorporating a suggestion by @compnerd to temporarily re-enable CUDA builds against these example models.